### PR TITLE
Add dummy skip index

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexSkipEven.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexSkipEven.cpp
@@ -1,0 +1,128 @@
+#include <Storages/MergeTree/MergeTreeIndexSkipEven.h>
+
+#include <IO/ReadBuffer.h>
+#include <IO/WriteBuffer.h>
+
+#include <Parsers/ASTFunction.h>
+
+#include "MergeTreeIndices.h"
+
+namespace DB
+{
+
+MergeTreeIndexGranuleSkipEven::MergeTreeIndexGranuleSkipEven(const String & index_name_, const Block & index_sample_block_)
+    : index_name(index_name_)
+    , index_sample_block(index_sample_block_)
+{}
+
+void MergeTreeIndexGranuleSkipEven::serializeBinary(WriteBuffer & /*ostr*/) const
+{
+//    ostr.write("kek", 3);
+//    ostr.finalize();
+}
+
+void MergeTreeIndexGranuleSkipEven::deserializeBinary(ReadBuffer & /*istr*/, MergeTreeIndexVersion /*version*/)
+{
+//    char kek[3];
+//    istr.read(kek, 3);
+}
+
+bool MergeTreeIndexGranuleSkipEven::empty() const
+{
+    return false;
+}
+
+
+MergeTreeIndexAggregatorSkipEven::MergeTreeIndexAggregatorSkipEven(const String & index_name_,
+                                                                   const Block & index_sample_block_)
+    : index_name(index_name_)
+    , index_sample_block(index_sample_block_)
+{}
+
+bool MergeTreeIndexAggregatorSkipEven::empty() const
+{
+    return false;
+}
+
+MergeTreeIndexGranulePtr MergeTreeIndexAggregatorSkipEven::getGranuleAndReset()
+{
+    return std::make_shared<MergeTreeIndexGranuleSkipEven>(index_name, index_sample_block);
+}
+
+void MergeTreeIndexAggregatorSkipEven::update(const Block & /*block*/, size_t * /*pos*/, size_t /*limit*/)
+{
+    // pass
+}
+
+
+MergeTreeIndexConditionSkipEven::MergeTreeIndexConditionSkipEven(
+    const IndexDescription & index,
+    const SelectQueryInfo & /*query*/,
+    ContextPtr /*context*/)
+    : index_data_types(index.data_types)
+{}
+
+bool MergeTreeIndexConditionSkipEven::alwaysUnknownOrTrue() const
+{
+    return false;
+}
+
+bool MergeTreeIndexConditionSkipEven::mayBeTrueOnGranule(MergeTreeIndexGranulePtr /*idx_granule*/) const
+{
+    int num = rand() % 2;
+    return num == 1;
+}
+
+
+MergeTreeIndexSkipEven::MergeTreeIndexSkipEven(const IndexDescription & index_)
+    : IMergeTreeIndex(index_)
+{}
+
+
+MergeTreeIndexGranulePtr MergeTreeIndexSkipEven::createIndexGranule() const
+{
+    return std::make_shared<MergeTreeIndexGranuleSkipEven>(index.name, index.sample_block);
+}
+
+MergeTreeIndexAggregatorPtr MergeTreeIndexSkipEven::createIndexAggregator() const
+{
+    return std::make_shared<MergeTreeIndexAggregatorSkipEven>(index.name, index.sample_block);
+}
+
+MergeTreeIndexConditionPtr MergeTreeIndexSkipEven::createIndexCondition(
+    const SelectQueryInfo & query, ContextPtr context) const
+{
+    return std::make_shared<MergeTreeIndexConditionSkipEven>(index, query, context);
+}
+
+bool MergeTreeIndexSkipEven::mayBenefitFromIndexForIn(const ASTPtr & node) const
+{
+    const String column_name = node->getColumnName();
+
+    for (const auto & cname : index.column_names)
+        if (column_name == cname)
+            return true;
+
+    if (const auto * func = typeid_cast<const ASTFunction *>(node.get()))
+        if (func->arguments->children.size() == 1)
+            return mayBenefitFromIndexForIn(func->arguments->children.front());
+
+    return false;
+}
+
+MergeTreeIndexFormat MergeTreeIndexSkipEven::getDeserializedFormat(const DiskPtr /*disk*/, const std::string & /*path_prefix*/) const
+{
+    return {1, ".idx"};
+}
+
+MergeTreeIndexPtr skipEvenIndexCreator(
+    const IndexDescription & index)
+{
+    return std::make_shared<MergeTreeIndexSkipEven>(index);
+}
+
+void skipEvenIndexValidator(const IndexDescription & /* index */, bool /* attach */)
+{
+}
+
+}

--- a/src/Storages/MergeTree/MergeTreeIndexSkipEven.h
+++ b/src/Storages/MergeTree/MergeTreeIndexSkipEven.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <Storages/MergeTree/MergeTreeIndices.h>
+#include <Storages/MergeTree/KeyCondition.h>
+
+namespace DB
+{
+
+struct MergeTreeIndexGranuleSkipEven final : public IMergeTreeIndexGranule
+{
+    MergeTreeIndexGranuleSkipEven(const String & index_name_, const Block & index_sample_block_);
+
+    ~MergeTreeIndexGranuleSkipEven() override = default;
+
+    void serializeBinary(WriteBuffer & ostr) const override;
+
+    void deserializeBinary(ReadBuffer & istr, MergeTreeIndexVersion version) override;
+
+    bool empty() const override;
+
+    String index_name;
+    Block index_sample_block;
+};
+
+
+struct MergeTreeIndexAggregatorSkipEven final : IMergeTreeIndexAggregator
+{
+    MergeTreeIndexAggregatorSkipEven(const String & index_name_, const Block & index_sample_block_);
+    ~MergeTreeIndexAggregatorSkipEven() override = default;
+
+    bool empty() const override;
+    MergeTreeIndexGranulePtr getGranuleAndReset() override;
+    void update(const Block & block, size_t * pos, size_t limit) override;
+
+    String index_name;
+    Block index_sample_block;
+};
+
+
+class MergeTreeIndexConditionSkipEven final : public IMergeTreeIndexCondition
+{
+public:
+    MergeTreeIndexConditionSkipEven(
+        const IndexDescription & index,
+        const SelectQueryInfo & query,
+        ContextPtr context);
+    ~MergeTreeIndexConditionSkipEven() override = default;
+
+    bool alwaysUnknownOrTrue() const override;
+
+    bool mayBeTrueOnGranule(MergeTreeIndexGranulePtr idx_granule) const override;
+
+private:
+    DataTypes index_data_types;
+};
+
+
+class MergeTreeIndexSkipEven : public IMergeTreeIndex
+{
+public:
+    explicit MergeTreeIndexSkipEven(const IndexDescription & index_);
+
+    ~MergeTreeIndexSkipEven() override = default;
+
+    MergeTreeIndexGranulePtr createIndexGranule() const override;
+    MergeTreeIndexAggregatorPtr createIndexAggregator() const override;
+
+    MergeTreeIndexConditionPtr createIndexCondition(
+        const SelectQueryInfo & query, ContextPtr context) const override;
+
+    bool mayBenefitFromIndexForIn(const ASTPtr & node) const override;
+
+    const char* getSerializedFileExtension() const override { return ".idx"; }
+    MergeTreeIndexFormat getDeserializedFormat(const DiskPtr disk, const std::string & path_prefix) const override;
+};
+
+
+}

--- a/src/Storages/MergeTree/MergeTreeIndexSkipEven.h
+++ b/src/Storages/MergeTree/MergeTreeIndexSkipEven.h
@@ -70,7 +70,7 @@ public:
 
     bool mayBenefitFromIndexForIn(const ASTPtr & node) const override;
 
-    const char* getSerializedFileExtension() const override { return ".idx"; }
+    const char* getSerializedFileExtension() const override { return ".idx2"; }
     MergeTreeIndexFormat getDeserializedFormat(const DiskPtr disk, const std::string & path_prefix) const override;
 };
 

--- a/src/Storages/MergeTree/MergeTreeIndices.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndices.cpp
@@ -84,6 +84,9 @@ void MergeTreeIndexFactory::validate(const IndexDescription & index, bool attach
 
 MergeTreeIndexFactory::MergeTreeIndexFactory()
 {
+    registerCreator("skipeven", skipEvenIndexCreator);
+    registerValidator("skipeven", skipEvenIndexValidator);
+
     registerCreator("minmax", minmaxIndexCreator);
     registerValidator("minmax", minmaxIndexValidator);
 

--- a/src/Storages/MergeTree/MergeTreeIndices.h
+++ b/src/Storages/MergeTree/MergeTreeIndices.h
@@ -208,6 +208,9 @@ private:
     Validators validators;
 };
 
+MergeTreeIndexPtr skipEvenIndexCreator(const IndexDescription & index);
+void skipEvenIndexValidator(const IndexDescription & index, bool attach);
+
 MergeTreeIndexPtr minmaxIndexCreator(const IndexDescription & index);
 void minmaxIndexValidator(const IndexDescription & index, bool attach);
 


### PR DESCRIPTION
Changelog category (leave one):
- New Feature


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add dummy skip index that can skip granules based on the random.


