### PR TITLE
Choose granules for big granularity

### DIFF
--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -1,4 +1,5 @@
 #include <boost/rational.hpp>   /// For calculations related to sampling coefficients.
+#include <cstddef>
 #include <optional>
 #include <unordered_set>
 
@@ -7,6 +8,7 @@
 #include <Storages/MergeTree/MergeTreeIndices.h>
 #include <Storages/MergeTree/MergeTreeIndexReader.h>
 #include <Storages/MergeTree/KeyCondition.h>
+#include <Storages/MergeTree/MergeTreeIndicesANNCondition.h>
 #include <Storages/MergeTree/MergeTreeDataPartUUID.h>
 #include <Storages/ReadInOrderOptimizer.h>
 #include <Parsers/ASTIdentifier.h>
@@ -1549,6 +1551,7 @@ MarkRanges MergeTreeDataSelectExecutor::filterMarksUsingIndex(
     /// this variable is stored to avoid reading the same granule twice.
     MergeTreeIndexGranulePtr granule = nullptr;
     size_t last_index_mark = 0;
+
     for (size_t i = 0; i < ranges.size(); ++i)
     {
         const MarkRange & index_range = index_ranges[i];
@@ -1562,6 +1565,30 @@ MarkRanges MergeTreeDataSelectExecutor::filterMarksUsingIndex(
         {
             if (index_mark != index_range.begin || !granule || last_index_mark != index_range.begin)
                 granule = reader.read();
+            // Cast to Ann condition
+            auto ann_condition  = std::dynamic_pointer_cast<IMergeTreeIndexConditionAnn>(condition);
+            if (ann_condition != nullptr)
+            {
+                // vector of indexes of useful ranges
+                auto result = ann_condition->getUsefulRanges(granule);
+                bool is_skipped = result.empty();
+                for (auto range_idx : result)
+                {
+                    // range for corresponding index
+                    MarkRange data_range(
+                        std::max(ranges[i].begin, index_mark * index_granularity + range_idx),
+                        std::min(ranges[i].end, index_mark * index_granularity + range_idx + 1));
+
+                    if (res.empty() || res.back().end - data_range.begin > min_marks_for_seek)
+                        res.push_back(data_range);
+                    else
+                        res.back().end = data_range.end;
+                }
+
+                if (is_skipped)
+                    ++granules_dropped;
+                continue;
+            }
 
             MarkRange data_range(
                     std::max(ranges[i].begin, index_mark * index_granularity),
@@ -1581,7 +1608,6 @@ MarkRanges MergeTreeDataSelectExecutor::filterMarksUsingIndex(
 
         last_index_mark = index_range.end - 1;
     }
-
     return res;
 }
 

--- a/src/Storages/MergeTree/MergeTreeIndicesANNCondition.h
+++ b/src/Storages/MergeTree/MergeTreeIndicesANNCondition.h
@@ -1,0 +1,11 @@
+#include <Storages/MergeTree/MergeTreeIndices.h>
+#include <vector>
+namespace DB
+{
+// condition interface for Ann indexes. Returns vector of indexes of ranges in granule which are useful for query.
+class IMergeTreeIndexConditionAnn: public IMergeTreeIndexCondition
+{
+    public:
+    virtual std::vector<size_t> getUsefulRanges(MergeTreeIndexGranulePtr idx_granule) const = 0;
+};
+}


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
